### PR TITLE
feat: add buildUrl parser option

### DIFF
--- a/src/__tests__/amp-img.test.ts
+++ b/src/__tests__/amp-img.test.ts
@@ -202,11 +202,13 @@ describe.each([
   ],
   [
     "buildUrlでMAX CDN を差し替えるtest👩",
-    {buildUrl: (codepoints, assetType) => {
-      return assetType === "png"
-      ? `/emoji/72x72/${codepoints}.png`
-      : `/emoji/svg/${codepoints}.svg`;
-    }},
+    {
+      buildUrl: (codepoints, assetType) => {
+        return assetType === "png"
+          ? `/emoji/72x72/${codepoints}.png`
+          : `/emoji/svg/${codepoints}.svg`;
+      },
+    },
     [
       "buildUrlでMAX CDN を差し替えるtest",
       {

--- a/src/__tests__/amp-img.test.ts
+++ b/src/__tests__/amp-img.test.ts
@@ -200,6 +200,24 @@ describe.each([
       `${String.fromCodePoint(65039)}(←ここにいる)amp-imgにせず無視するよ`,
     ],
   ],
+  [
+    "buildUrlでMAX CDN を差し替えるtest👩",
+    {buildUrl: (codepoints, assetType) => {
+      return assetType === "png"
+      ? `/emoji/72x72/${codepoints}.png`
+      : `/emoji/svg/${codepoints}.svg`;
+    }},
+    [
+      "buildUrlでMAX CDN を差し替えるtest",
+      {
+        src: "/emoji/svg/1f469.svg",
+        width: 32,
+        height: 32,
+        alt: "👩",
+        class: "emoji",
+      },
+    ],
+  ],
 ] as testType)("emojify(%s) params %o", (input, options, expected) => {
   test(`should have img.emoji ${input} ${options}`, () => {
     const s = twemojify(input, createImgElement, options);

--- a/src/__tests__/img.test.ts
+++ b/src/__tests__/img.test.ts
@@ -202,11 +202,13 @@ describe.each([
   ],
   [
     "buildUrlでMAX CDN を差し替えるtest👩",
-    {buildUrl: (codepoints, assetType) => {
-      return assetType === "png"
-      ? `/emoji/72x72/${codepoints}.png`
-      : `/emoji/svg/${codepoints}.svg`;
-    }},
+    {
+      buildUrl: (codepoints, assetType) => {
+        return assetType === "png"
+          ? `/emoji/72x72/${codepoints}.png`
+          : `/emoji/svg/${codepoints}.svg`;
+      },
+    },
     [
       "buildUrlでMAX CDN を差し替えるtest",
       {

--- a/src/__tests__/img.test.ts
+++ b/src/__tests__/img.test.ts
@@ -200,6 +200,24 @@ describe.each([
       `${String.fromCodePoint(65039)}(←ここにいる)imgにせず無視するよ`,
     ],
   ],
+  [
+    "buildUrlでMAX CDN を差し替えるtest👩",
+    {buildUrl: (codepoints, assetType) => {
+      return assetType === "png"
+      ? `/emoji/72x72/${codepoints}.png`
+      : `/emoji/svg/${codepoints}.svg`;
+    }},
+    [
+      "buildUrlでMAX CDN を差し替えるtest",
+      {
+        src: "/emoji/svg/1f469.svg",
+        width: 32,
+        height: 32,
+        alt: "👩",
+        class: "emoji",
+      },
+    ],
+  ],
 ] as testType)("emojify(%s) params %o", (input, options, expected) => {
   test(`should have img.emoji ${input} ${options}`, () => {
     const s = twemojify(input, createImgElement, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ export function twemojify(
   const size = (opts && opts.size) || 32;
   const style = opts && opts.style;
   const assetType = (opts && opts.assetType) || "svg";
-  const emojis = parse(text, { assetType });
+  const buildUrl = opts && opts.buildUrl;
+  const emojis = parse(text, { assetType, buildUrl });
   const className = (opts && opts.class) || "emoji";
   const result: Array<string | React.ReactElement> = [];
   let position = 0;

--- a/types/twemoji-parser.d.ts
+++ b/types/twemoji-parser.d.ts
@@ -1,7 +1,7 @@
 declare module "twemoji-parser" {
   type Options = {
     assetType?: "png" | "svg";
-    buildUrl?: (codepoints: string, assetType: string) => string,
+    buildUrl?: (codepoints: string, assetType: string) => string;
   };
   type EmojiEntity = {
     type: "emoji";

--- a/types/twemoji-parser.d.ts
+++ b/types/twemoji-parser.d.ts
@@ -1,6 +1,7 @@
 declare module "twemoji-parser" {
   type Options = {
     assetType?: "png" | "svg";
+    buildUrl?: (codepoints: string, assetType: string) => string,
   };
   type EmojiEntity = {
     type: "emoji";


### PR DESCRIPTION
buildUrl option: https://github.com/twitter/twemoji-parser/blob/13.0.0/src/index.js#L14

Usage: 
```
const { twemojify } = require('react-twemojify');
const { createImgElement }  = require('react-twemojify/lib/img');
const result = twemojify('Hello World 🙆', createImgElement, {
    buildUrl: (codepoints: string, assetType: string) => {
      return assetType === "png"
        ? `/emoji/72x72/${codepoints}.png`
        : `/emoji/svg/${codepoints}.svg`;
    }
});
```